### PR TITLE
Rebuild portfolio around resume-driven storytelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
-# mina-professional-website
-Professional Portfolio Website
+# Mina Mekhael — Professional Portfolio
+
+A single-page portfolio designed to translate Mina Mekhael’s product setup expertise, Salesforce leadership, and automation storytelling into an immersive digital experience.
+
+## Overview
+
+- Cinematic hero section with key outcomes and focus areas.
+- Story, selected work, experience timeline, approach, skills, and contact sections crafted from the latest resume highlights.
+- Mobile navigation menu, interactive skill spotlight, and live year stamp handled with lightweight JavaScript.
+- Responsive layout with high-contrast design inspired by sunset and glassmorphism motifs.
+
+## Project structure
+
+```
+├── index.html      # Page markup and content
+├── styles.css      # Visual system and responsive layout
+├── script.js       # Navigation toggle, skill spotlight, year helper
+└── assets/
+    └── README.md   # Guidance for adding custom media (resume, imagery)
+```
+
+## Getting started
+
+1. Clone or download this repository.
+2. Add personal assets following the notes in `assets/README.md` (resume PDF, hero image, etc.).
+3. Open `index.html` directly in a browser or serve locally:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+4. Visit [http://localhost:8000](http://localhost:8000) to preview the portfolio.
+
+## Customization checklist
+
+- **Copy:** Update section content in `index.html` to reflect new accomplishments, testimonials, or focus areas.
+- **Navigation:** Adjust anchor links and section IDs if you add or remove major sections.
+- **Visuals:** Modify CSS custom properties at the top of `styles.css` to tweak colors, typography, and glow effects.
+- **Interactions:** Extend `script.js` if you introduce new components that require interactivity (carousels, analytics, etc.).
+- **Assets:** Replace placeholder external links (LinkedIn, GitHub, calendar) with your actual profiles.
+
+## Accessibility & testing tips
+
+- Validate color contrast when changing the palette to maintain readability against the dark background.
+- Ensure new imagery includes descriptive alt text and that focus states remain visible.
+- Test navigation and section spacing on mobile devices—the header is sticky, so confirm anchor targets have adequate scroll offset.
+
+## Launch & maintenance
+
+- Host on a static-friendly platform such as GitHub Pages, Netlify, or Vercel for quick publishing.
+- Schedule quarterly content reviews to refresh metrics, add recent wins, and keep links current.
+- Maintain version control for asset updates (resume, imagery) so you can roll back if needed.
+
+## License
+
+This project is provided for personal portfolio use.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,9 @@
+# Assets
+
+Place personalized media in this directory to complete the portfolio experience.
+
+- `Mina_Mekhael_Resume.pdf` — the downloadable resume referenced in the hero section.
+- `hero-portrait.jpg` (optional) — a cropped or stylized portrait used for the hero background if you choose to update the CSS with a background image.
+- Any additional imagery (project screenshots, badges, etc.) that you reference from `index.html`.
+
+> Tip: Keep filenames descriptive and update paths in the HTML/CSS whenever you swap in new assets.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mina Mekhael | Professional Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Inter:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header" id="top">
+    <a class="brand" href="#top">
+      <span class="brand-mark" aria-hidden="true">MM</span>
+      <span class="brand-text">Mina Mekhael</span>
+    </a>
+    <button class="nav-toggle" id="navToggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primaryNav">
+      <span class="nav-toggle__bar" aria-hidden="true"></span>
+      <span class="nav-toggle__bar" aria-hidden="true"></span>
+      <span class="nav-toggle__bar" aria-hidden="true"></span>
+    </button>
+    <nav class="site-nav" id="primaryNav" aria-label="Primary navigation">
+      <a href="#profile">Profile</a>
+      <a href="#story">Story</a>
+      <a href="#work">Work</a>
+      <a href="#experience">Experience</a>
+      <a href="#skills">Skills</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero" id="profile">
+      <div class="hero-inner">
+        <div class="hero-copy">
+          <p class="eyebrow">Reflections of Innovation</p>
+          <h1>Senior Product Setup Engineer &amp; Salesforce Strategist</h1>
+          <p class="hero-lede">
+            I design automation-first release programs that keep enterprise SaaS launches compliant, human-centered, and ready to scale. From Salesforce orchestration to workflow storytelling, I bridge product, engineering, and compliance teams so every rollout lands with confidence.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn--primary" href="mailto:mekhaelm@gmail.com">Start a conversation</a>
+            <a class="btn btn--ghost" href="assets/Mina_Mekhael_Resume.pdf" download>Download resume</a>
+          </div>
+          <ul class="hero-metrics" aria-label="Key outcomes">
+            <li><span class="metric-value">7+ years</span><span class="metric-label">launching enterprise platforms</span></li>
+            <li><span class="metric-value">40% faster</span><span class="metric-label">onboarding through automation</span></li>
+            <li><span class="metric-value">99% success</span><span class="metric-label">across production releases</span></li>
+          </ul>
+        </div>
+        <aside class="hero-pane" aria-label="Current focus areas">
+          <div class="pane-card">
+            <h2>What I’m focused on</h2>
+            <ul>
+              <li>Designing audit-ready Salesforce configurations for studio and government clients.</li>
+              <li>Coaching cross-functional teams through Jira-led release rituals.</li>
+              <li>Mapping automation blueprints that turn complex requirements into trustable products.</li>
+            </ul>
+          </div>
+          <div class="pane-card">
+            <h2>Beyond the backlog</h2>
+            <p>
+              First-generation technologist, community mentor, and storyteller translating systems thinking into human impact.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section section--story" id="story">
+      <div class="section-heading">
+        <h2>Why I build</h2>
+        <p>From Pomona curiosity to enterprise reliability.</p>
+      </div>
+      <div class="section-content section-content--split">
+        <article>
+          <p>
+            I grew up fascinated by the way technology can open doors. Today I deliver Salesforce-integrated solutions that honor that curiosity—listening deeply, pairing automation with accountability, and making every workflow more intuitive for the people who rely on it.
+          </p>
+          <p>
+            My path spans customer consulting, full-stack training, and product delivery. The common thread: translating ambiguity into empathetic, metrics-driven experiences that stakeholders can trust.
+          </p>
+        </article>
+        <aside class="pill-list" aria-label="Guiding principles">
+          <h3>Guiding principles</h3>
+          <ul>
+            <li>Lead with discovery and plain-language storytelling.</li>
+            <li>Prototype fast, validate rigorously, and document transparently.</li>
+            <li>Scale enablement alongside every automation.</li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section section--cases" id="work">
+      <div class="section-heading">
+        <h2>Selected work</h2>
+        <p>Case studies that turned complexity into clarity.</p>
+      </div>
+      <div class="case-grid" role="list">
+        <article class="case-card" role="listitem">
+          <header>
+            <p class="case-meta">Entertainment Partners · 2020 – Present</p>
+            <h3>Enterprise platform onboarding orchestration</h3>
+          </header>
+          <p>
+            Architected the setup playbook for Salesforce-integrated products supporting mission-critical studio and government operations. Automated field validation, security models, and data flows so teams could deploy confidently.
+          </p>
+          <ul>
+            <li>Standardized deployment pipeline cut configuration time by 40%.</li>
+            <li>Validation suites reduced downstream errors by 30%.</li>
+            <li>Release scorecards earned a 99% production success rate.</li>
+          </ul>
+        </article>
+        <article class="case-card" role="listitem">
+          <header>
+            <p class="case-meta">Entertainment Partners · 2020 – Present</p>
+            <h3>Salesforce release accelerator</h3>
+          </header>
+          <p>
+            Led Jira-managed sprints across engineering, legal, and compliance centers of excellence. Defined acceptance criteria, prioritized backlogs, and launched new capabilities on schedule while preserving audit readiness.
+          </p>
+          <ul>
+            <li>Release velocity improved by 25% through automation-first rituals.</li>
+            <li>Cross-functional playbooks elevated stakeholder alignment.</li>
+            <li>Adoption programs increased feature usage across partner teams.</li>
+          </ul>
+        </article>
+        <article class="case-card" role="listitem">
+          <header>
+            <p class="case-meta">Verizon Wireless · 2015 – 2019</p>
+            <h3>Client adoption and enablement programs</h3>
+          </header>
+          <p>
+            Delivered tailored technical solutions for enterprise and mid-market clients while leading trainings that demystified new tools. Empowered teams to make data-informed decisions and strengthened long-term retention.
+          </p>
+          <ul>
+            <li>Workflow improvements boosted operational efficiency by 25%.</li>
+            <li>Adoption workshops lifted satisfaction and renewals.</li>
+            <li>Feedback loops informed roadmap enhancements.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section section--experience" id="experience">
+      <div class="section-heading">
+        <h2>Career journey</h2>
+        <p>Roles that shaped my perspective.</p>
+      </div>
+      <div class="timeline" aria-label="Professional experience timeline">
+        <article class="timeline-item">
+          <div class="timeline-marker" aria-hidden="true"></div>
+          <div class="timeline-content">
+            <h3>Senior Product Setup Engineer</h3>
+            <p class="timeline-meta">Entertainment Partners · 2020 – Present</p>
+            <ul>
+              <li>Orchestrate Salesforce-integrated implementations for studio and government partners.</li>
+              <li>Lead agile rituals that translate complex requirements into actionable sprints.</li>
+              <li>Champion automation to improve release efficiency, quality, and adoption.</li>
+            </ul>
+          </div>
+        </article>
+        <article class="timeline-item">
+          <div class="timeline-marker" aria-hidden="true"></div>
+          <div class="timeline-content">
+            <h3>Solutions Consultant</h3>
+            <p class="timeline-meta">Verizon Wireless · 2015 – 2019</p>
+            <ul>
+              <li>Delivered technology solutions that improved workflows and retention.</li>
+              <li>Facilitated trainings that aligned implementations with organizational goals.</li>
+              <li>Partnered with technical teams to streamline onboarding.</li>
+            </ul>
+          </div>
+        </article>
+        <article class="timeline-item">
+          <div class="timeline-marker" aria-hidden="true"></div>
+          <div class="timeline-content">
+            <h3>Account Manager</h3>
+            <p class="timeline-meta">Rosland Capital · 2013 – 2015</p>
+            <ul>
+              <li>Managed high-value portfolios with data-informed, relationship-driven strategies.</li>
+              <li>Increased referrals by 15% through proactive engagement.</li>
+              <li>Gathered insights that strengthened services and repeat business.</li>
+            </ul>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section section--approach" id="approach">
+      <div class="section-heading">
+        <h2>How I partner</h2>
+        <p>Every engagement is a shared build.</p>
+      </div>
+      <div class="approach-grid">
+        <article class="approach-card">
+          <h3>Listen for nuance</h3>
+          <p>Start with active discovery sessions that map context, constraints, and people impact.</p>
+        </article>
+        <article class="approach-card">
+          <h3>Co-create clarity</h3>
+          <p>Translate findings into diagrams, demos, and documentation teams can own.</p>
+        </article>
+        <article class="approach-card">
+          <h3>Measure what matters</h3>
+          <p>Define success metrics, build dashboards, and revisit outcomes to keep progress visible.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section section--skills" id="skills">
+      <div class="section-heading">
+        <h2>Toolkit in action</h2>
+        <p>Select a focus area to see how it comes to life.</p>
+      </div>
+      <div class="skills-grid" role="list">
+        <button class="skill-card" type="button" role="listitem" data-skill-detail="Sales Cloud, Service Cloud, Flow, Process Builder, validation rules, and reporting tailored for regulated environments.">
+          <span>Salesforce Administration</span>
+        </button>
+        <button class="skill-card" type="button" role="listitem" data-skill-detail="Regression, functional, and UAT strategies embedded in CI/CD pipelines for predictable releases.">
+          <span>QA Strategy &amp; Testing</span>
+        </button>
+        <button class="skill-card" type="button" role="listitem" data-skill-detail="YAML-driven configuration templates and automation pipelines that cut release cycles by 25%.">
+          <span>Automation &amp; DevOps</span>
+        </button>
+        <button class="skill-card" type="button" role="listitem" data-skill-detail="Jira, Confluence, and Asana frameworks that align stakeholders around outcomes and readiness.">
+          <span>Agile Delivery</span>
+        </button>
+        <button class="skill-card" type="button" role="listitem" data-skill-detail="JavaScript, React, and HTML/CSS storytelling that turns data into intuitive dashboards and trainings.">
+          <span>Product Storytelling</span>
+        </button>
+        <button class="skill-card" type="button" role="listitem" data-skill-detail="Certified Scrum Product Owner who blends empathy, metrics, and facilitation to drive adoption.">
+          <span>Leadership &amp; Enablement</span>
+        </button>
+      </div>
+      <div class="skill-detail" id="skillDetail" role="status" aria-live="polite"></div>
+    </section>
+
+    <section class="section section--contact" id="contact">
+      <div class="section-heading">
+        <h2>Let’s collaborate</h2>
+        <p>Reach out for product implementation, automation strategy, or mentorship conversations.</p>
+      </div>
+      <div class="contact-grid">
+        <article class="contact-card">
+          <h3>Contact</h3>
+          <ul>
+            <li><span class="label">Email</span> <a href="mailto:mekhaelm@gmail.com">mekhaelm@gmail.com</a></li>
+            <li><span class="label">Phone</span> <a href="tel:13104821086">310-482-1086</a></li>
+            <li><span class="label">Location</span> Los Angeles, CA</li>
+          </ul>
+        </article>
+        <article class="contact-card">
+          <h3>Connect</h3>
+          <ul>
+            <li><a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a></li>
+            <li><a href="https://github.com" target="_blank" rel="noreferrer">GitHub</a></li>
+            <li><a href="https://cal.com" target="_blank" rel="noreferrer">Book a coffee chat</a></li>
+          </ul>
+        </article>
+        <article class="contact-card">
+          <h3>Credentials</h3>
+          <ul>
+            <li>Certified Scrum Product Owner (CSPO)</li>
+            <li>Flatiron School — Full Stack Web Development</li>
+            <li>California State University, Northridge — B.A.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>© <span id="year"></span> Mina Mekhael. Crafted for equitable, human-centered systems.</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,42 @@
+const navToggle = document.getElementById('navToggle');
+const primaryNav = document.getElementById('primaryNav');
+const skillCards = document.querySelectorAll('.skill-card');
+const skillDetail = document.getElementById('skillDetail');
+const yearEl = document.getElementById('year');
+
+const toggleNavigation = () => {
+  if (!navToggle || !primaryNav) return;
+  const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+  navToggle.setAttribute('aria-expanded', String(!expanded));
+  primaryNav.classList.toggle('is-open');
+};
+
+navToggle?.addEventListener('click', toggleNavigation);
+
+primaryNav?.querySelectorAll('a').forEach((link) => {
+  link.addEventListener('click', () => {
+    if (!primaryNav.classList.contains('is-open')) return;
+    navToggle?.setAttribute('aria-expanded', 'false');
+    primaryNav.classList.remove('is-open');
+  });
+});
+
+const updateSkillDetail = (card) => {
+  const detail = card.getAttribute('data-skill-detail');
+  if (!detail || !skillDetail) return;
+  skillDetail.textContent = detail;
+  skillCards.forEach((btn) => btn.classList.toggle('active', btn === card));
+};
+
+skillCards.forEach((card) => {
+  card.addEventListener('click', () => updateSkillDetail(card));
+  card.addEventListener('focus', () => updateSkillDetail(card));
+});
+
+if (skillCards.length) {
+  updateSkillDetail(skillCards[0]);
+}
+
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,720 @@
+:root {
+  --color-background: #050b1a;
+  --color-surface: rgba(13, 24, 45, 0.85);
+  --color-surface-strong: #101f36;
+  --color-primary: #ff6f61;
+  --color-secondary: #ffc857;
+  --color-text: #f5f7fa;
+  --color-muted: #b8c4d6;
+  --color-border: rgba(255, 255, 255, 0.14);
+  --shadow-soft: 0 24px 48px -32px rgba(5, 11, 26, 0.9);
+  --shadow-card: 0 20px 40px -28px rgba(10, 18, 33, 0.95);
+  --font-heading: 'Playfair Display', serif;
+  --font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: radial-gradient(circle at top right, rgba(49, 106, 173, 0.45), transparent 60%),
+    radial-gradient(circle at bottom left, rgba(250, 128, 114, 0.35), transparent 55%),
+    var(--color-background);
+  line-height: 1.6;
+  min-height: 100vh;
+  letter-spacing: 0.01em;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--color-secondary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.section,
+.hero {
+  padding: 6rem 1.5rem;
+}
+
+.section {
+  position: relative;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.section::after {
+  content: '';
+  position: absolute;
+  inset: 1.5rem;
+  z-index: -1;
+  background: linear-gradient(140deg, rgba(255, 111, 97, 0.12), rgba(58, 122, 94, 0.1));
+  border-radius: 2rem;
+  filter: blur(64px);
+  opacity: 0.6;
+}
+
+.section-heading {
+  max-width: 620px;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 3vw + 1rem, 2.8rem);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.section-heading p {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.section-content--split {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.section-content--split article,
+.section-content--split aside {
+  background: var(--color-surface);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid var(--color-border);
+}
+
+.section-content--split p {
+  margin-top: 0;
+  color: var(--color-muted);
+}
+
+.section-content--split p + p {
+  margin-top: 1.2rem;
+}
+
+.pill-list ul {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.pill-list li {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.75rem 1.25rem;
+  color: var(--color-text);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  background: rgba(5, 11, 26, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(255, 111, 97, 0.65), rgba(255, 200, 87, 0.65));
+  font-weight: 700;
+  font-family: var(--font-heading);
+}
+
+.brand-text {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.site-nav a {
+  text-decoration: none;
+  color: var(--color-muted);
+  font-weight: 500;
+  font-size: 0.95rem;
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--color-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.site-nav a:focus-visible::after,
+.site-nav a:hover::after {
+  transform: scaleX(1);
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 0.75rem;
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+  color: var(--color-text);
+}
+
+.nav-toggle__bar {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: currentColor;
+}
+
+.nav-toggle__bar + .nav-toggle__bar {
+  margin-top: 4px;
+}
+
+.hero {
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 2.5rem;
+  background: linear-gradient(145deg, rgba(255, 111, 97, 0.18), rgba(58, 122, 94, 0.16));
+  z-index: -2;
+  filter: blur(40px);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 2.5rem;
+  background: rgba(9, 18, 33, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  z-index: -1;
+  box-shadow: var(--shadow-card);
+}
+
+.hero-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
+  gap: 3rem;
+}
+
+.hero-copy {
+  padding: 3rem;
+}
+
+.hero-pane {
+  display: grid;
+  gap: 1.5rem;
+  padding: 3rem 3rem 3rem 0;
+}
+
+.pane-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.pane-card h2 {
+  margin-top: 0;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+}
+
+.pane-card ul {
+  margin: 1.5rem 0 0;
+  padding-left: 1.25rem;
+  color: var(--color-muted);
+  line-height: 1.7;
+}
+
+.hero .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.75rem;
+  color: var(--color-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.5rem, 4vw + 1rem, 3.6rem);
+  line-height: 1.1;
+  margin: 0 0 1.25rem;
+}
+
+.hero-lede {
+  color: var(--color-muted);
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--color-primary), #ff907f);
+  color: #0a1220;
+  box-shadow: 0 14px 28px -18px rgba(255, 111, 97, 0.9);
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px -16px rgba(255, 111, 97, 0.85);
+}
+
+.btn--ghost {
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  color: var(--color-text);
+  background: transparent;
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--color-secondary);
+}
+
+.hero-metrics {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.25rem;
+  padding: 0;
+  margin: 0;
+}
+
+.hero-metrics li {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+.metric-value {
+  display: block;
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.metric-label {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.case-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.case-card {
+  background: rgba(8, 17, 31, 0.88);
+  border-radius: 1.75rem;
+  padding: 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.case-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 111, 97, 0.12), transparent 55%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.case-card header {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 1.5rem;
+}
+
+.case-card h3 {
+  font-family: var(--font-heading);
+  margin: 0.25rem 0 0;
+  font-size: 1.7rem;
+}
+
+.case-card p,
+.case-card ul {
+  position: relative;
+  z-index: 1;
+  color: var(--color-muted);
+}
+
+.case-card ul {
+  margin-top: 1.5rem;
+  padding-left: 1.25rem;
+  line-height: 1.8;
+}
+
+.case-meta {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.timeline {
+  display: grid;
+  gap: 2.5rem;
+  position: relative;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 18px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(to bottom, rgba(255, 111, 97, 0.4), rgba(63, 132, 104, 0.4));
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 1.5rem;
+}
+
+.timeline-marker {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(255, 111, 97, 0.8), rgba(255, 200, 87, 0.8));
+  border: 2px solid rgba(5, 11, 26, 0.8);
+  margin-top: 0.35rem;
+  box-shadow: 0 10px 24px -18px rgba(255, 200, 135, 0.8);
+}
+
+.timeline-content {
+  background: rgba(8, 17, 31, 0.9);
+  border-radius: 1.5rem;
+  padding: 1.75rem 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-soft);
+}
+
+.timeline-content h3 {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-heading);
+}
+
+.timeline-meta {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 1rem;
+}
+
+.timeline-content ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+  line-height: 1.7;
+}
+
+.approach-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.approach-card {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.approach-card h3 {
+  margin-top: 0;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+}
+
+.approach-card p {
+  color: var(--color-muted);
+}
+
+.skills-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.skill-card {
+  background: rgba(8, 17, 31, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.5rem;
+  padding: 1.2rem 1.5rem;
+  color: inherit;
+  text-align: left;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+  box-shadow: var(--shadow-soft);
+}
+
+.skill-card:hover,
+.skill-card:focus-visible {
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+}
+
+.skill-card.active {
+  border-color: var(--color-secondary);
+}
+
+.skill-detail {
+  margin-top: 2rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--color-muted);
+  min-height: 88px;
+}
+
+.section--contact .contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.contact-card {
+  background: rgba(8, 17, 31, 0.9);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.contact-card h3 {
+  margin-top: 0;
+  font-family: var(--font-heading);
+}
+
+.contact-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--color-muted);
+}
+
+.contact-card a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.contact-card a:hover,
+.contact-card a:focus-visible {
+  color: var(--color-secondary);
+}
+
+.contact-card .label {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 0.25rem;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 3rem 1.5rem 4rem;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+}
+
+section {
+  scroll-margin-top: 120px;
+}
+
+@media (max-width: 1100px) {
+  .hero-inner {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .hero-pane {
+    padding: 0 3rem 3rem;
+  }
+}
+
+@media (max-width: 900px) {
+  .site-nav {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    right: 1.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+    background: rgba(6, 13, 27, 0.96);
+    padding: 1.5rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 24px 48px -28px rgba(0, 0, 0, 0.75);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+  }
+
+  .site-nav.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .site-nav a {
+    padding: 0.25rem 0;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .section-content--split {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .hero {
+    padding: 5rem 1.5rem 4rem;
+  }
+
+  .hero-copy,
+  .hero-pane {
+    padding: 2.5rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    font-size: 0.95rem;
+  }
+
+  .section,
+  .hero {
+    padding: 4.5rem 1.25rem;
+  }
+
+  .section::after {
+    inset: 1rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.2rem, 7vw, 3rem);
+  }
+
+  .hero-metrics {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .skill-detail {
+    padding: 1.25rem 1.4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the hero, work, experience, and skills sections with resume-aligned storytelling and measurable outcomes
- refresh the visual system with a dusk-inspired palette, responsive layout, and mobile navigation menu
- streamline JavaScript to support navigation toggling, skill spotlights, and the live copyright year
- update documentation with structure, customization guidance, and asset requirements

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e5c4d989e8833094d8a7f8e4924076